### PR TITLE
I added equation support to rst2beamer

### DIFF
--- a/rst2beamer.py
+++ b/rst2beamer.py
@@ -1335,7 +1335,7 @@ class BeamerTranslator (LaTeXTranslator):
     ## copied from sphinx.ext.mathbase
 
     def visit_math(self, node):
-        self.body.append('$' + node['latex'] + '$')
+        self.out.append('$' + node['latex'] + '$')
         raise nodes.SkipNode
 
     def visit_displaymath(self, node):


### PR DESCRIPTION
Hi, I added basic equation support to your latest rst2beamer code by copying code from Sphinx with some modifications to make it work in this context.  My initial version supports inline equations via the :math:`c^2=a^2+b^2` syntax that Sphinx uses, and "displaymath" equations via the .. math:: directive that Sphinx uses.  This means I can use the same reST file to generate HTML (with equations rendered by jsmath), latex documents, or as slides via beamer.  I haven't yet made equation label references work, although I copied the basic Sphinx code to do that it will probably require some modification.

Let me know if you have questions or critiques.

-- Chris Lee
